### PR TITLE
vmware-player: Fix accessing rc file

### DIFF
--- a/app-emulation/vmware-player/vmware-player-6.0.6.2700073.ebuild
+++ b/app-emulation/vmware-player/vmware-player-6.0.6.2700073.ebuild
@@ -204,7 +204,7 @@ src_install() {
 	local initscript="${T}/vmware.rc"
 
 	sed -e "s:@@BINDIR@@:${VM_INSTALL_DIR}/bin:g" \
-		"${FILESDIR}/vmware-3.0.rc" > "${initscript}" || die
+		"${FILESDIR}/vmware-11.2.rc" > "${initscript}" || die
 	newinitd "${initscript}" vmware || die
 
 	# fill in variable placeholders

--- a/app-emulation/vmware-player/vmware-player-7.1.0.2496824.ebuild
+++ b/app-emulation/vmware-player/vmware-player-7.1.0.2496824.ebuild
@@ -203,7 +203,7 @@ src_install() {
 	local initscript="${T}/vmware.rc"
 
 	sed -e "s:@@BINDIR@@:${VM_INSTALL_DIR}/bin:g" \
-		"${FILESDIR}/vmware-3.0.rc" > "${initscript}" || die
+		"${FILESDIR}/vmware-11.2.rc" > "${initscript}" || die
 	newinitd "${initscript}" vmware || die
 
 	# fill in variable placeholders

--- a/app-emulation/vmware-player/vmware-player-7.1.2.2780323.ebuild
+++ b/app-emulation/vmware-player/vmware-player-7.1.2.2780323.ebuild
@@ -203,7 +203,7 @@ src_install() {
 	local initscript="${T}/vmware.rc"
 
 	sed -e "s:@@BINDIR@@:${VM_INSTALL_DIR}/bin:g" \
-		"${FILESDIR}/vmware-3.0.rc" > "${initscript}" || die
+		"${FILESDIR}/vmware-11.2.rc" > "${initscript}" || die
 	newinitd "${initscript}" vmware || die
 
 	# fill in variable placeholders


### PR DESCRIPTION
The runscript `files/vmware-3.0rc` is present in the tree, but not in this overlay. A short look into 11.2rc leads to the assumption that would be okay to use the provided version instead of pushing 3.0rc from the tree to this overlay.
