### PR TITLE
Fix vmware-modules-304.2 compilation against gentoo-sources-4.1

### DIFF
--- a/app-emulation/vmware-modules/files/304-3.17-00-netdev.patch
+++ b/app-emulation/vmware-modules/files/304-3.17-00-netdev.patch
@@ -1,0 +1,16 @@
+new alloc_netdev requires a new parameter. All examples in the kernel i've seen just
+use the constant NET_NAME_UNKNOWN.
+origionally from: https://communities.vmware.com/message/2425189
+
+diff -rupN vmnet-only/netif.c vmnet-only.new/netif.c
+--- vmnet-only/netif.c	2013-11-06 00:40:52.000000000 -0500
++++ vmnet-only.new/netif.c	2014-10-09 17:29:12.361307961 -0400
+@@ -149,7 +149,7 @@ VNetNetIf_Create(char *devName,  // IN:
+    memcpy(deviceName, devName, sizeof deviceName);
+    NULL_TERMINATE_STRING(deviceName);
+ 
+-   dev = alloc_netdev(sizeof *netIf, deviceName, VNetNetIfSetup);
++   dev = alloc_netdev(sizeof *netIf, deviceName, NET_NAME_USER, VNetNetIfSetup);
+    if (!dev) {
+       retval = -ENOMEM;
+       goto out;

--- a/app-emulation/vmware-modules/files/304-3.19-01-dentry.patch
+++ b/app-emulation/vmware-modules/files/304-3.19-01-dentry.patch
@@ -1,14 +1,40 @@
 There is an level of abstrxtion in the newre API as of 3.19 here
 --- a/vmnet-only/driver.c	2015-02-07 03:54:17.000000000 +0300
 +++ c/vmnet-only/driver.c	2015-02-24 03:58:06.043605137 +0300
-@@ -1191,8 +1191,8 @@
+@@ -265,10 +265,17 @@
+ {
+    int ret = -ENOTTY;
+
++#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
+    if (filp && filp->f_op && filp->f_op->ioctl == VNetFileOpIoctl) {
+       ret = VNetFileOpIoctl(filp->f_dentry->d_inode, filp, iocmd, ioarg);
+    }
+    return ret;
++#else
++   if (filp && filp->f_op && filp->f_op->ioctl == VNetFileOpIoctl) {
++      ret = VNetFileOpIoctl(filp->f_path.dentry->d_inode, filp, iocmd, ioarg);
++   }
++   return ret;
++#endif
+ }
+
+
+@@ -1191,11 +1198,19 @@
     struct inode *inode = NULL;
     long err;
 
--   if (filp && filp->f_dentry) {
--      inode = filp->f_dentry->d_inode;
-+   if (filp && filp->f_path.dentry) {
-+      inode = filp->f_path.dentry->d_inode;
++#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
+    if (filp && filp->f_dentry) {
+       inode = filp->f_dentry->d_inode;
     }
     err = VNetFileOpIoctl(inode, filp, iocmd, ioarg);
     return err;
++#else
++   if (filp && filp->f_path.dentry) {
++      inode = filp->f_path.dentry->d_inode;
++   }
++   err = VNetFileOpIoctl(inode, filp, iocmd, ioarg);
++   return err;
++#endif
+ }
+ #endif

--- a/app-emulation/vmware-modules/files/304-3.19-04-iovec.patch
+++ b/app-emulation/vmware-modules/files/304-3.19-04-iovec.patch
@@ -9,41 +9,23 @@ Some parts of the iovec API were replaced by the similar message API. Refactorin
  
  #include "compat_highmem.h"
  #include "compat_interrupt.h"
-@@ -1196,21 +1197,21 @@
-       } else {
-          toCopy = size - bytesCopied;
+@@ -1224,3 +1225,3 @@
        }
 -
 +      /* Code cloned from kernels drivers/misc/vmw_vmci/vmci_queue_pair.c */
        if (isIovec) {
+@@ -1227,1 +1228,1 @@
 -         struct iovec *iov = (struct iovec *)src;
--         int err;
 +         struct msghdr *msg = (struct msghdr *)src;
-+         int err;
- 
+@@ -1230,2 +1231,2 @@
 -         /* The iovec will track bytesCopied internally. */
 -         err = memcpy_fromiovec((uint8 *)va + pageOffset, iov, toCopy);
--         if (err != 0) {
--            if (kernelIf->host) {
--               kunmap(kernelIf->u.h.page[pageIndex]);
 +         /* The iovec will track bytes_copied internally. */
 +         err = memcpy_from_msg((u8 *)va + pageOffset, msg, toCopy);
-+         if (err != 0) {
-+            if (kernelIf->host)
-+               kunmap(kernelIf->u.h.page[pageIndex]);
-+               return VMCI_ERROR_INVALID_ARGS;
-             }
--            return VMCI_ERROR_INVALID_ARGS;
--         }
--      } else {
+@@ -1239,1 +1240,1 @@
 -         memcpy((uint8 *)va + pageOffset, (uint8 *)src + bytesCopied, toCopy);
-+        } else {
-+            memcpy((u8 *)va + pageOffset,
-+                   (u8 *)src + bytesCopied, toCopy);
-       }
- 
-       bytesCopied += toCopy;
-@@ -1273,11 +1274,11 @@
++         memcpy((u8 *)va + pageOffset, (u8 *)src + bytesCopied, toCopy);
+@@ -1300,11 +1301,11 @@
        }
  
        if (isIovec) {

--- a/app-emulation/vmware-modules/files/304-4.1-00-vmnet.patch
+++ b/app-emulation/vmware-modules/files/304-4.1-00-vmnet.patch
@@ -1,0 +1,17 @@
+nf_hookfn changed in 4.1
+--- a/vmnet-only/filter.c    2013-08-27 20:29:04.000000000 +0100
++++ b/vmnet-only/filter.c    2015-08-11 21:57:51.188231884 +0300
+@@ -213,9 +213,13 @@
+ #else
+                  struct sk_buff **pskb,                // IN:
+ #endif
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
++                 const struct nf_hook_state *state)
++#else
+                  const struct net_device *in,          // IN:
+                  const struct net_device *out,         // IN:
+                  int (*okfn)(struct sk_buff *))        // IN:
++#endif
+ {
+ #ifndef VMW_NFHOOK_USES_SKB
+    struct sk_buff *skb = *pskb;

--- a/app-emulation/vmware-modules/vmware-modules-304.2.ebuild
+++ b/app-emulation/vmware-modules/vmware-modules-304.2.ebuild
@@ -86,15 +86,17 @@ src_prepare() {
 	kernel_is ge 3 11 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.11-00-readdir.patch"
 	kernel_is ge 3 11 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.11-01-filldir.patch"
 	kernel_is ge 3 15 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.15-00-vsock.patch"
+	kernel_is ge 3 17 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.17-00-netdev.patch"
 	kernel_is ge 3 18 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.18-00-version-redefined.patch"
 	kernel_is ge 3 19 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.19-00-compat-namei.patch"
-	#kernel_is ge 3 19 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.19-01-dentry.patch"
+	kernel_is ge 3 19 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.19-01-dentry.patch"
 	kernel_is ge 3 19 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.19-02-vmblock-path.patch"
-	#kernel_is ge 3 19 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.19-03-iovec.patch"
+	kernel_is ge 3 19 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.19-03-iovec.patch"
 	kernel_is ge 3 19 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.19-04-iovec.patch"
 	kernel_is ge 3 19 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.19-05-vmci_qpair.patch"
 	kernel_is ge 3 19 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.19-06-vsock.patch"
 	kernel_is ge 3 19 0 && epatch "${FILESDIR}/${PV_MAJOR}-3.19-07-vsock.patch"
+	kernel_is ge 4 1 0 && epatch "${FILESDIR}/${PV_MAJOR}-4.1-00-vmnet.patch"
 
 	# Allow user patches so they can support RC kernels and whatever else
 	epatch_user


### PR DESCRIPTION
`304-4.1-00-vmnet.patch` required because of https://github.com/torvalds/linux/commit/238e54c9cb9385a1ba99e92801f3615a2fb398b6
