### PR TITLE
app-emulation/vmware-modules: add support for kernel 4.9

### DIFF
--- a/app-emulation/vmware-modules/files/308-4.09-00-user-pages.patch
+++ b/app-emulation/vmware-modules/files/308-4.09-00-user-pages.patch
@@ -1,0 +1,77 @@
+--- vmmon-only/linux/hostif.c	2016-12-12 09:17:44.438182532 -0700
++++ vmmon-only/linux/hostif.c	2016-12-12 09:19:24.066254301 -0700
+@@ -1172,7 +1172,11 @@
+ #else
+    retval = get_user_pages(current, current->mm, (unsigned long)uvAddr,
+ #endif
+-                           numPages, 0, 0, ppages, NULL);
++                           numPages, 0,
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0)
++                           0,
++#endif
++			   ppages, NULL);
+    up_read(&current->mm->mmap_sem);
+ 
+    return retval != numPages;
+--- vmnet-only/userif.c     2016-12-12 09:27:12.445246854 -0700
++++ vmnet-only/userif.c 2016-12-12 09:27:30.654298646 -0700
+@@ -118,7 +118,13 @@
+ #else
+    retval = get_user_pages(current, current->mm, addr,
+ #endif
+-			   1, 1, 0, &page, NULL);
++                          1,
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0)
++                          1, 0,
++#else
++                          FOLL_WRITE,
++#endif
++                          &page, NULL);
+    up_read(&current->mm->mmap_sem);
+ 
+    if (retval != 1) {
+--- vmci-only/linux/driver.c        2016-12-12 09:38:13.076847013 -0700
++++ vmci-only/linux/driver.c    2016-12-12 09:38:45.638087445 -0700
+@@ -1473,7 +1473,13 @@
+ #else
+    retval = get_user_pages(current, current->mm, addr,
+ #endif
+-                           1, 1, 0, &page, NULL);
++                          1,
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0)
++                          1, 0,
++#else
++                          FOLL_WRITE,
++#endif
++                          &page, NULL);
+    up_read(&current->mm->mmap_sem);
+ 
+    if (retval != 1) {
+--- vmci-only/linux/vmciKernelIf.c  2016-12-12 09:38:20.678904322 -0700
++++ vmci-only/linux/vmciKernelIf.c      2016-12-12 09:39:59.129587451 -0700
+@@ -2061,7 +2061,11 @@
+                            (VA)produceUVA,
+ #endif
+                            produceQ->kernelIf->numPages,
+-                           1, 0,
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0)
++                          1, 0,
++#else
++                          FOLL_WRITE,
++#endif
+                            produceQ->kernelIf->u.h.headerPage,
+                            NULL);
+    if (retval < produceQ->kernelIf->numPages) {
+@@ -2079,7 +2083,11 @@
+                            (VA)consumeUVA,
+ #endif
+                            consumeQ->kernelIf->numPages,
+-                           1, 0,
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0)
++                          1, 0,
++#else
++                          FOLL_WRITE,
++#endif
+                            consumeQ->kernelIf->u.h.headerPage,
+                            NULL);
+    if (retval < consumeQ->kernelIf->numPages) {

--- a/app-emulation/vmware-modules/vmware-modules-308.1.1.ebuild
+++ b/app-emulation/vmware-modules/vmware-modules-308.1.1.ebuild
@@ -105,6 +105,7 @@ src_prepare() {
 	kernel_is ge 4 7 0 && epatch "${FILESDIR}/${PV_MAJOR}-4.07-00-trans_start.patch"
 	kernel_is ge 4 7 0 && epatch "${FILESDIR}/${PV_MAJOR}-4.07-01-readlink_copy.patch"
 	kernel_is ge 4 8 0 && epatch "${FILESDIR}/${PV_MAJOR}-4.08-00-nr_anon_mapped.patch"
+	kernel_is ge 4 9 0 && epatch "${FILESDIR}/${PV_MAJOR}-4.09-00-user-pages.patch"
 
 	# Allow user patches so they can support RC kernels and whatever else
 	epatch_user


### PR DESCRIPTION
4.9 introduced a change to the get_user_pages() API:
https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=768ae309a96103ed02eb1e111e838c87854d8b51

I've tested this locally and it seems to be working fine.