### PR TITLE
app-emulation/vmware-modules: add support for kernel 4.10

### DIFF
--- a/app-emulation/vmware-modules/files/308-4.10-00-generic_readlink.patch
+++ b/app-emulation/vmware-modules/files/308-4.10-00-generic_readlink.patch
@@ -1,0 +1,14 @@
+--- vmblock-only/linux/inode.c	2017-02-21 08:38:50.844678686 -0700
++++ vmblock-only/linux/inode.c	2017-02-21 08:59:40.557917497 -0700
+@@ -207,8 +207,10 @@
+ 	return vfs_readlink(dentry, buffer, buflen, iinfo->name);
+ #elif LINUX_VERSION_CODE <= KERNEL_VERSION(4, 6, 99)
+     return readlink_copy(buffer, buflen, iinfo->name);
+-#else
++#elif LINUX_VERSION_CODE <= KERNEL_VERSION(4, 9, 99)
+     return generic_readlink(dentry, buffer, buflen);
++#else
++    return vfs_readlink(dentry, buffer, buflen);
+ #endif
+ }
+ 

--- a/app-emulation/vmware-modules/vmware-modules-308.1.1.ebuild
+++ b/app-emulation/vmware-modules/vmware-modules-308.1.1.ebuild
@@ -106,6 +106,7 @@ src_prepare() {
 	kernel_is ge 4 7 0 && epatch "${FILESDIR}/${PV_MAJOR}-4.07-01-readlink_copy.patch"
 	kernel_is ge 4 8 0 && epatch "${FILESDIR}/${PV_MAJOR}-4.08-00-nr_anon_mapped.patch"
 	kernel_is ge 4 9 0 && epatch "${FILESDIR}/${PV_MAJOR}-4.09-00-user-pages.patch"
+	kernel_is ge 4 10 0 && epatch "${FILESDIR}/${PV_MAJOR}-4.10-00-generic_readlink.patch"
 
 	# Allow user patches so they can support RC kernels and whatever else
 	epatch_user


### PR DESCRIPTION
What's old is new again! 4.10 brought back vfs_readlink():
https://github.com/torvalds/linux/commit/231753ef780012eb6f3922c3dfc0a7186baa33c2