### PR TITLE
Fix a memory leak in vmmon for Linux 4.13.0+.

### DIFF
--- a/app-emulation/vmware-modules/files/308-4.13-01-vmmon-page-accounting.patch
+++ b/app-emulation/vmware-modules/files/308-4.13-01-vmmon-page-accounting.patch
@@ -1,0 +1,63 @@
+diff --git a/vmmon-only/linux/hostif.c b/vmmon-only/linux/hostif.c
+index 80b5787..c0d1d60 100644
+--- a/vmmon-only/linux/hostif.c
++++ b/vmmon-only/linux/hostif.c
+@@ -99,6 +99,37 @@
+ #include "vmmonInt.h"
+ #include "versioned_atomic.h"
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
++#   define global_zone_page_state global_page_state
++#endif
++
++static unsigned long get_nr_slab_unreclaimable(void)
++{
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
++   return global_node_page_state(NR_SLAB_UNRECLAIMABLE);
++#else
++   return global_page_state(NR_SLAB_UNRECLAIMABLE);
++#endif
++}
++
++static unsigned long get_nr_unevictable(void)
++{
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
++   return global_node_page_state(NR_UNEVICTABLE);
++#else
++   return global_page_state(NR_UNEVICTABLE);
++#endif
++}
++
++static unsigned long get_nr_anon_mapped(void)
++{
++ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
++   return global_node_page_state(NR_ANON_MAPPED);
++ #else
++   return global_page_state(NR_ANON_PAGES);
++ #endif
++}
++
+ /*
+  * Determine if we can use high resolution timers.
+  */
+@@ -1594,16 +1625,11 @@ HostIF_EstimateLockedPageLimit(const VMDriver* vm,                // IN
+    unsigned int reservedPages = MEMDEFAULTS_MIN_HOST_PAGES;
+    unsigned int hugePages = (vm == NULL) ? 0 :
+       BYTES_2_PAGES(vm->memInfo.hugePageBytes);
+-   unsigned int lockedPages = global_page_state(NR_PAGETABLE) +
+-                              global_page_state(NR_SLAB_UNRECLAIMABLE) +
+-                              global_page_state(NR_UNEVICTABLE) +
++   unsigned int lockedPages = global_zone_page_state(NR_PAGETABLE) +
++                              get_nr_slab_unreclaimable() +
++                              get_nr_unevictable() +
+                               hugePages + reservedPages;
+-   unsigned int anonPages =
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
+-      global_page_state(NR_ANON_MAPPED);
+-#else
+-      global_page_state(NR_ANON_PAGES);
+-#endif
++   unsigned int anonPages = get_nr_anon_mapped();
+    unsigned int swapPages = BYTES_2_PAGES(linuxState.swapSize);
+ 
+    if (anonPages > swapPages) {

--- a/app-emulation/vmware-modules/vmware-modules-308.5.7.ebuild
+++ b/app-emulation/vmware-modules/vmware-modules-308.5.7.ebuild
@@ -111,6 +111,7 @@ src_prepare() {
 	kernel_is ge 4 12 0 && epatch "${FILESDIR}/${PV_MAJOR}-4.12-01-vmci-do_once.patch"
 	kernel_is ge 4 12 0 && epatch "${FILESDIR}/${PV_MAJOR}-4.12-02-vmci-pci_enable_msix.patch"
 	kernel_is ge 4 13 0 && epatch "${FILESDIR}/${PV_MAJOR}-4.13-00-vmnet-refcount.patch"
+	kernel_is ge 4 13 0 && epatch "${FILESDIR}/${PV_MAJOR}-4.13-01-vmmon-page-accounting.patch"
 
 	# Allow user patches so they can support RC kernels and whatever else
 	epatch_user


### PR DESCRIPTION
Apparently changes in the 4.13-rc series led to a memory leak in
vmmon.  For more details see the commit message from the origin
of this patch:

https://github.com/mkubecek/vmware-host-modules/commit/b50848c985f1a6c0a341187346d77f0119d0a835