### PR TITLE
Fix check for new kernel option on older kernels.

### DIFF
--- a/app-emulation/vmware-modules/vmware-modules-308.5.9.ebuild
+++ b/app-emulation/vmware-modules/vmware-modules-308.5.9.ebuild
@@ -28,7 +28,9 @@ S=${WORKDIR}
 
 pkg_setup() {
 	CONFIG_CHECK="~HIGH_RES_TIMERS"
-	CONFIG_CHECK="${CONFIG_CHECK} X86_IOPL_IOPERM" # this is needed to avoid startup problems with vmnet-natd
+	if kernel_is ge 5 5 0; then
+		CONFIG_CHECK="${CONFIG_CHECK} X86_IOPL_IOPERM" # this is needed to avoid startup problems with vmnet-natd
+	fi
 	if kernel_is ge 2 6 37 && kernel_is lt 2 6 39; then
 		CONFIG_CHECK="${CONFIG_CHECK} BKL"
 	fi


### PR DESCRIPTION
X86_IOPL_IOPERM was added in kernel 5.5.0, so will not be present on
older kernels.